### PR TITLE
Align input field and search button

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -28,6 +28,7 @@ html, body {
   outline: none;
   font-family: 'Dosis', sans-serif;
   font-size: 1.2rem;
+  vertical-align: middle;
 }
 
 .search_btn {
@@ -38,4 +39,5 @@ html, body {
   height: 44px;
   width: 44px;
   outline: none;
+  vertical-align: middle;
 }


### PR DESCRIPTION
I just added a CSS rule (`vertical-align: middle`) to align the input and button elements that have a default display of `inline-block`. It seems to fix the problem :smile: (which I came across a lot online when searching on Google!)